### PR TITLE
Fix for png output

### DIFF
--- a/src/sim/util/io/stream/RTSPStreamer.java
+++ b/src/sim/util/io/stream/RTSPStreamer.java
@@ -292,7 +292,7 @@ public class RTSPStreamer extends VideoStreamer {
 	    	FullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, httpBuffer);
 	    	httpResponse.headers().add(HttpHeaderNames.PRAGMA, "no-cache");
 	        httpResponse.headers().add(HttpHeaderNames.CONTENT_TYPE, "image/png");
-	        httpResponse.headers().add(HttpHeaderNames.CONTENT_LENGTH, buffer);
+	        httpResponse.headers().add(HttpHeaderNames.CONTENT_LENGTH, buffer.length);
 	        
 			ctx.writeAndFlush(httpResponse);
 			ctx.close();


### PR DESCRIPTION
Restore the .length method to buffer, inadvertently removed in 4001cc72d74237fbd7146a1402dc40a6d23ce9a4.